### PR TITLE
SSL Support out of the box

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -220,13 +220,15 @@ const server: Server = Bun.serve({
 let sslRedirect: Server;
 
 if (serverPort === 443) {
+    let cacheHostname: string;
     sslRedirect = Bun.serve({
         port: 80,
         fetch: (req: Request): Promise<Response> => {
+            if (!cacheHostname) cacheHostname = new URL(req.url).hostname;
             return Promise.resolve(new Response(null, {
                 status: 301,
                 headers: {
-                    location: "https://0.0.0.0"
+                    location: "https://" + cacheHostname
                 }
             }));
         },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -193,15 +193,19 @@ if (process.env.PROD == "true") {
     try {
         tlsSettings["key"] = Bun.file("./sslKeys/key.pem");
         tlsSettings["cert"] = Bun.file("./sslKeys/cert.pem");
+        if (!tlsSettings["key"].size || !tlsSettings["cert"].size) {
+            throw new Error();
+        }
         tlsSettings["passphrase"] = config["sslPassphrase"];
     } catch (e) {
         console.log("SSL keys are non-existent. Will use HTTP.");
+        tlsSettings["key"] = null;
+        tlsSettings["cert"] = null;
     }
     if (tlsSettings["key"] && tlsSettings["cert"]) {
         serverPort = 443;
     }
 }
-
 
 const server: Server = Bun.serve({
     port: serverPort,

--- a/sslKeys/SSLSupport.md
+++ b/sslKeys/SSLSupport.md
@@ -7,4 +7,4 @@ Make sure you're in this folder and run the following.
 ``certbot certonly --standalone``
 
 ``cp /etc/letsencrypt/live/[my url]/fullchain.pem cert.pem``
-``cp /etc/letsencrypt/live/parra.to/privkey.pem key.pem``
+``cp /etc/letsencrypt/live/[my url]/privkey.pem key.pem``

--- a/sslKeys/SSLSupport.md
+++ b/sslKeys/SSLSupport.md
@@ -1,3 +1,10 @@
 # SSL Support
 
 TODO. It's supported supposedly.
+
+Make sure you're in this folder and run the following.
+
+``certbot certonly --standalone``
+
+``cp /etc/letsencrypt/live/[my url]/fullchain.pem cert.pem``
+``cp /etc/letsencrypt/live/parra.to/privkey.pem key.pem``


### PR DESCRIPTION
Two things happen now:

if running production, we check for TLS cert and key. 

If found, we use 443 and basically forward all 80 traffic to 443. Otherwise we use 80.